### PR TITLE
Fix: Azure SQL does not support linked servers

### DIFF
--- a/TSQL_Depends/TSQL_Depends/Models/ModelBuilder.cs
+++ b/TSQL_Depends/TSQL_Depends/Models/ModelBuilder.cs
@@ -47,14 +47,22 @@ namespace TSQL.Depends.Models
 
 		public List<TSQLServer> GetServers()
 		{
-			return GetModelList<TSQLServer>(
-				Script.GetServers,
-				(reader, model) =>
-				{
-					model.Name = reader["server_name"].ToString();
+			try
+			{
+				return GetModelList<TSQLServer>(
+					Script.GetServers,
+					(reader, model) =>
+					{
+						model.Name = reader["server_name"].ToString();
 
-					model.IsLinked = (bool)reader["is_linked"];
-				});
+						model.IsLinked = (bool)reader["is_linked"];
+					});
+			}
+			catch (SqlException exception) when (exception.Message.ToLower()
+				                                     .Contains("invalid object name 'sys.servers'"))
+			{
+				return new List<TSQLServer>();
+			}
 		}
 
 		public List<TSQLDatabase> GetDatabases()


### PR DESCRIPTION
Hi,

This adds at least partial support for Azure SQL. I don't know if there are other compatibility issues with Azure SQL, but this allowed me to get dependencies for a few SQL scripts in an Azure SQL DB.

It was failing on GetServers, because you can't query `sys.servers` in Azure SQL.